### PR TITLE
[HYD-142] Docker build failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: zalando/spilo
           token: ${{ secrets.GH_TOKEN }}
-          ref: 2.1-p6
+          ref: 2.1-p7
           path: spilo
 
       # Set versions

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -36,6 +36,7 @@ target "spilo" {
   context = "../spilo/postgres-appliance"
   args = {
     TIMESCALEDB = ""
+    PGOLDVERSIONS = 13
   }
 }
 

--- a/files/all/postgres-appliance/scripts/configure_spilo.py
+++ b/files/all/postgres-appliance/scripts/configure_spilo.py
@@ -188,6 +188,9 @@ bootstrap:
       {{#STANDBY_PORT}}
       port: {{STANDBY_PORT}}
       {{/STANDBY_PORT}}
+      {{#STANDBY_PRIMARY_SLOT_NAME}}
+      primary_slot_name: {{STANDBY_PRIMARY_SLOT_NAME}}
+      {{/STANDBY_PRIMARY_SLOT_NAME}}
     {{/STANDBY_CLUSTER}}
     ttl: 30
     loop_wait: &loop_wait 10
@@ -613,6 +616,7 @@ def get_placeholders(provider):
     placeholders.setdefault('STANDBY_WITH_WALE', '')
     placeholders.setdefault('STANDBY_HOST', '')
     placeholders.setdefault('STANDBY_PORT', '')
+    placeholders.setdefault('STANDBY_PRIMARY_SLOT_NAME', '')
     placeholders.setdefault('STANDBY_CLUSTER', placeholders['STANDBY_WITH_WALE'] or placeholders['STANDBY_HOST'])
 
     if provider == PROVIDER_AWS and not USE_KUBERNETES:
@@ -769,7 +773,8 @@ def write_log_environment(placeholders):
 def write_wale_environment(placeholders, prefix, overwrite):
     s3_names = ['WALE_S3_PREFIX', 'WALG_S3_PREFIX', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY',
                 'WALE_S3_ENDPOINT', 'AWS_ENDPOINT', 'AWS_REGION', 'AWS_INSTANCE_PROFILE', 'WALE_DISABLE_S3_SSE',
-                'WALG_S3_SSE_KMS_ID', 'WALG_S3_SSE', 'WALG_DISABLE_S3_SSE', 'AWS_S3_FORCE_PATH_STYLE']
+                'WALG_S3_SSE_KMS_ID', 'WALG_S3_SSE', 'WALG_DISABLE_S3_SSE', 'AWS_S3_FORCE_PATH_STYLE', 'AWS_ROLE_ARN',
+                'AWS_WEB_IDENTITY_TOKEN_FILE']
     azure_names = ['WALG_AZ_PREFIX', 'AZURE_STORAGE_ACCOUNT', 'AZURE_STORAGE_ACCESS_KEY',
                    'AZURE_STORAGE_SAS_TOKEN', 'WALG_AZURE_BUFFER_SIZE', 'WALG_AZURE_MAX_BUFFERS',
                    'AZURE_ENVIRONMENT_NAME']

--- a/files/all/postgres-appliance/scripts/post_init.sh
+++ b/files/all/postgres-appliance/scripts/post_init.sh
@@ -176,14 +176,14 @@ while IFS= read -r db_name; do
     # In case if timescaledb binary is missing the first query fails with the error
     # ERROR:  could not access file "$libdir/timescaledb-$OLD_VERSION": No such file or directory
     UPGRADE_TIMESCALEDB=$(echo -e "SELECT NULL;\nSELECT default_version != installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'timescaledb'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-    if [ "x$UPGRADE_TIMESCALEDB" = "xt" ]; then
+    if [ "$UPGRADE_TIMESCALEDB" = "t" ]; then
         echo "ALTER EXTENSION timescaledb UPDATE;"
     fi
     UPGRADE_POSTGIS=$(echo -e "SELECT COUNT(*) FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-    if [ "x$UPGRADE_POSTGIS" = "x1" ]; then
+    if [ "$UPGRADE_POSTGIS" = "1" ]; then
         # public.postgis_lib_version() is available only if postgis extension is created
         UPGRADE_POSTGIS=$(echo -e "SELECT extversion != public.postgis_lib_version() FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-        if [ "x$UPGRADE_POSTGIS" = "xt" ]; then
+        if [ "$UPGRADE_POSTGIS" = "t" ]; then
             echo "ALTER EXTENSION postgis UPDATE;"
             echo "SELECT public.postgis_extensions_upgrade();"
         fi
@@ -204,7 +204,7 @@ GRANT EXECUTE ON FUNCTION public.pg_stat_statements_reset($RESET_ARGS) TO admin;
     else
         echo "GRANT EXECUTE ON FUNCTION pg_catalog.pg_switch_wal() TO admin;"
     fi
-    if [ "x$ENABLE_PG_MON" = "xtrue" ] && [ "$PGVER" -ge 11 ]; then echo "CREATE EXTENSION IF NOT EXISTS pg_mon SCHEMA public;"; fi
+    if [ "$ENABLE_PG_MON" = "true" ] && [ "$PGVER" -ge 11 ]; then echo "CREATE EXTENSION IF NOT EXISTS pg_mon SCHEMA public;"; fi
     cat metric_helpers.sql
 done < <(psql -d "$2" -tAc 'select pg_catalog.quote_ident(datname) from pg_catalog.pg_database where datallowconn')
 ) | PGOPTIONS="-c synchronous_commit=local" psql -Xd "$2"

--- a/files/default/postgres-appliance/scripts/configure_spilo.py
+++ b/files/default/postgres-appliance/scripts/configure_spilo.py
@@ -188,6 +188,9 @@ bootstrap:
       {{#STANDBY_PORT}}
       port: {{STANDBY_PORT}}
       {{/STANDBY_PORT}}
+      {{#STANDBY_PRIMARY_SLOT_NAME}}
+      primary_slot_name: {{STANDBY_PRIMARY_SLOT_NAME}}
+      {{/STANDBY_PRIMARY_SLOT_NAME}}
     {{/STANDBY_CLUSTER}}
     ttl: 30
     loop_wait: &loop_wait 10
@@ -613,6 +616,7 @@ def get_placeholders(provider):
     placeholders.setdefault('STANDBY_WITH_WALE', '')
     placeholders.setdefault('STANDBY_HOST', '')
     placeholders.setdefault('STANDBY_PORT', '')
+    placeholders.setdefault('STANDBY_PRIMARY_SLOT_NAME', '')
     placeholders.setdefault('STANDBY_CLUSTER', placeholders['STANDBY_WITH_WALE'] or placeholders['STANDBY_HOST'])
 
     if provider == PROVIDER_AWS and not USE_KUBERNETES:
@@ -769,7 +773,8 @@ def write_log_environment(placeholders):
 def write_wale_environment(placeholders, prefix, overwrite):
     s3_names = ['WALE_S3_PREFIX', 'WALG_S3_PREFIX', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY',
                 'WALE_S3_ENDPOINT', 'AWS_ENDPOINT', 'AWS_REGION', 'AWS_INSTANCE_PROFILE', 'WALE_DISABLE_S3_SSE',
-                'WALG_S3_SSE_KMS_ID', 'WALG_S3_SSE', 'WALG_DISABLE_S3_SSE', 'AWS_S3_FORCE_PATH_STYLE']
+                'WALG_S3_SSE_KMS_ID', 'WALG_S3_SSE', 'WALG_DISABLE_S3_SSE', 'AWS_S3_FORCE_PATH_STYLE', 'AWS_ROLE_ARN',
+                'AWS_WEB_IDENTITY_TOKEN_FILE']
     azure_names = ['WALG_AZ_PREFIX', 'AZURE_STORAGE_ACCOUNT', 'AZURE_STORAGE_ACCESS_KEY',
                    'AZURE_STORAGE_SAS_TOKEN', 'WALG_AZURE_BUFFER_SIZE', 'WALG_AZURE_MAX_BUFFERS',
                    'AZURE_ENVIRONMENT_NAME']

--- a/files/default/postgres-appliance/scripts/post_init.sh
+++ b/files/default/postgres-appliance/scripts/post_init.sh
@@ -176,14 +176,14 @@ while IFS= read -r db_name; do
     # In case if timescaledb binary is missing the first query fails with the error
     # ERROR:  could not access file "$libdir/timescaledb-$OLD_VERSION": No such file or directory
     UPGRADE_TIMESCALEDB=$(echo -e "SELECT NULL;\nSELECT default_version != installed_version FROM pg_catalog.pg_available_extensions WHERE name = 'timescaledb'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-    if [ "x$UPGRADE_TIMESCALEDB" = "xt" ]; then
+    if [ "$UPGRADE_TIMESCALEDB" = "t" ]; then
         echo "ALTER EXTENSION timescaledb UPDATE;"
     fi
     UPGRADE_POSTGIS=$(echo -e "SELECT COUNT(*) FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-    if [ "x$UPGRADE_POSTGIS" = "x1" ]; then
+    if [ "$UPGRADE_POSTGIS" = "1" ]; then
         # public.postgis_lib_version() is available only if postgis extension is created
         UPGRADE_POSTGIS=$(echo -e "SELECT extversion != public.postgis_lib_version() FROM pg_catalog.pg_extension WHERE extname = 'postgis'" | psql -tAX -d "${db_name}" 2> /dev/null | tail -n 1)
-        if [ "x$UPGRADE_POSTGIS" = "xt" ]; then
+        if [ "$UPGRADE_POSTGIS" = "t" ]; then
             echo "ALTER EXTENSION postgis UPDATE;"
             echo "SELECT public.postgis_extensions_upgrade();"
         fi
@@ -202,7 +202,7 @@ GRANT EXECUTE ON FUNCTION public.pg_stat_statements_reset($RESET_ARGS) TO admin;
     else
         echo "GRANT EXECUTE ON FUNCTION pg_catalog.pg_switch_wal() TO admin;"
     fi
-    if [ "x$ENABLE_PG_MON" = "xtrue" ] && [ "$PGVER" -ge 11 ]; then echo "CREATE EXTENSION IF NOT EXISTS pg_mon SCHEMA public;"; fi
+    if [ "$ENABLE_PG_MON" = "true" ] && [ "$PGVER" -ge 11 ]; then echo "CREATE EXTENSION IF NOT EXISTS pg_mon SCHEMA public;"; fi
     cat metric_helpers.sql
 done < <(psql -d "$2" -tAc 'select pg_catalog.quote_ident(datname) from pg_catalog.pg_database where datallowconn')
 ) | PGOPTIONS="-c synchronous_commit=local" psql -Xd "$2"


### PR DESCRIPTION
The docker build failed with the following:

```
ERROR: failed to solve: executor failed running [/bin/sh -c export DEBIAN_FRONTEND=noninteractive     && export MAKEFLAGS="-j $(grep -c ^processor /proc/cpuinfo)"     && set -ex     && sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list     && apt-get update     && cd /builddeps     && BUILD_PACKAGES="devscripts equivs build-essential fakeroot debhelper git gcc libc6-dev make cmake libevent-dev libbrotli-dev libssl-dev libkrb5-dev"     && if [ "$DEMO" = "true" ]; then         export DEB_PG_SUPPORTED_VERSIONS="$PGVERSION"         && WITH_PERL=false         && rm -f *.deb         && apt-get install -y $BUILD_PACKAGES;     else         BUILD_PACKAGES="$BUILD_PACKAGES zlib1g-dev libpam0g-dev libcurl4-openssl-dev libicu-dev python libc-ares-dev pandoc pkg-config"         && apt-get install -y $BUILD_PACKAGES libcurl4         && git clone -b $PAM_OAUTH2 --recurse-submodules https://github.com/CyberDem0n/pam-oauth2.git         && make -C pam-oauth2 install         && git clone -b $PLPROFILER https://github.com/bigsql/plprofiler.git         && tar -xzf plantuner-${PLANTUNER_COMMIT}.tar.gz         && curl -sL https://github.com/sdudoladov/pg_mon/archive/$PG_MON_COMMIT.tar.gz | tar xz         && for p in python3-keyring python3-docutils ieee-data; do             version=$(apt-cache show $p | sed -n 's/^Version: //p' | sort -rV | head -n 1)             && echo "Section: misc\nPriority: optional\nStandards-Version: 3.9.8\nPackage: $p\nVersion: $version\nDescription: $p" > $p             && equivs-build $p;         done;     fi     && if [ "$WITH_PERL" != "true" ]; then         version=$(apt-cache show perl | sed -n 's/^Version: //p' | sort -rV | head -n 1)         && echo "Section: misc\nPriority: optional\nStandards-Version: 3.9.8\nPackage: perl\nSection:perl\nMulti-Arch: allowed\nReplaces: perl-base\nVersion: $version\nDescription: perl" > perl         && equivs-build perl;     fi     && if [ "$WITH_PERL" != "true" ] || [ "$DEMO" != "true" ]; then dpkg -i *.deb || apt-get -y -f install; fi     && curl -sL https://github.com/CyberDem0n/bg_mon/archive/$BG_MON_COMMIT.tar.gz | tar xz     && curl -sL https://github.com/sdudoladov/pg_auth_mon/archive/$PG_AUTH_MON_COMMIT.tar.gz | tar xz     && curl -sL https://github.com/cybertec-postgresql/pg_permissions/archive/$PG_PERMISSIONS_COMMIT.tar.gz | tar xz     && curl -sL https://github.com/x4m/pg_tm_aux/archive/$PG_TM_AUX_COMMIT.tar.gz | tar xz     && git clone -b $SET_USER https://github.com/pgaudit/set_user.git     && git clone https://github.com/timescale/timescaledb.git     && apt-get install -y postgresql-common libevent-2.1 libevent-pthreads-2.1 brotli libbrotli1 python3.6 python3-psycopg2     && sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf     && for version in $DEB_PG_SUPPORTED_VERSIONS; do             sed -i "s/ main.*$/ main $version/g" /etc/apt/sources.list.d/pgdg.list             && apt-get update             && if [ "$DEMO" != "true" ]; then                 EXTRAS="postgresql-pltcl-${version}                         postgresql-${version}-dirtyread                         postgresql-${version}-extra-window-functions                         postgresql-${version}-first-last-agg                         postgresql-${version}-hll                         postgresql-${version}-hypopg                         postgresql-${version}-pgaudit                         postgresql-${version}-pg-checksums                         postgresql-${version}-pgl-ddl-deploy                         postgresql-${version}-pglogical                         postgresql-${version}-pglogical-ticker                         postgresql-${version}-pgq-node                         postgresql-${version}-pldebugger                         postgresql-${version}-pllua                         postgresql-${version}-plpgsql-check                         postgresql-${version}-plproxy                         postgresql-${version}-postgis-${POSTGIS_VERSION%.*}                         postgresql-${version}-postgis-${POSTGIS_VERSION%.*}-scripts                         postgresql-${version}-repack                         postgresql-${version}-wal2json"                 && if [ "$WITH_PERL" = "true" ]; then                     EXTRAS="$EXTRAS postgresql-plperl-${version}";                 fi                 && if [ ${version%.*} -ge 10 ]; then                     EXTRAS="$EXTRAS postgresql-${version}-decoderbufs";                 fi                 && if [ ${version%.*} -lt 11 ]; then                     EXTRAS="$EXTRAS postgresql-${version}-amcheck";                 fi;             fi             && apt-get install --allow-downgrades -y postgresql-contrib-${version}                     postgresql-plpython3-${version} postgresql-server-dev-${version}                     postgresql-${version}-cron postgresql-${version}-pgq3                     postgresql-${version}-pg-stat-kcache $EXTRAS             && cd timescaledb             && for v in $TIMESCALEDB; do                 git checkout $v                 && sed -i "s/VERSION 3.11/VERSION 3.10/" CMakeLists.txt                 && if BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DWARNINGS_AS_ERRORS=OFF                     -DTAP_CHECKS=OFF -DPG_CONFIG=/usr/lib/postgresql/$version/bin/pg_config                     -DAPACHE_ONLY=$TIMESCALEDB_APACHE_ONLY -DSEND_TELEMETRY_DEFAULT=NO; then                         make -C build install                         && strip /usr/lib/postgresql/$version/lib/timescaledb*.so;                 fi                 && git reset --hard                 && git clean -f -d;             done             && cd ..             && if [ "$DEMO" != "true" ]; then                 EXTRA_EXTENSIONS="plantuner-${PLANTUNER_COMMIT} plprofiler"                 && if [ ${version%.*} -ge 10 ]; then                      EXTRA_EXTENSIONS="$EXTRA_EXTENSIONS pg_mon-${PG_MON_COMMIT}";                 fi;             else                 EXTRA_EXTENSIONS="";             fi             && for n in bg_mon-${BG_MON_COMMIT} pg_auth_mon-${PG_AUTH_MON_COMMIT} set_user pg_permissions-${PG_PERMISSIONS_COMMIT} pg_tm_aux-${PG_TM_AUX_COMMIT} $EXTRA_EXTENSIONS; do                 make -C $n USE_PGXS=1 clean install-strip;             done;     done     && apt-get install -y skytools3-ticker pgbouncer     && sed -i "s/ main.*$/ main/g" /etc/apt/sources.list.d/pgdg.list     && apt-get update     && apt-get install -y postgresql postgresql-server-dev-all postgresql-all libpq-dev     && for version in $DEB_PG_SUPPORTED_VERSIONS; do         apt-get install -y postgresql-server-dev-${version};     done     && if [ "$DEMO" != "true" ]; then         for version in $DEB_PG_SUPPORTED_VERSIONS; do             apt-get install -y postgresql-${version}-partman             && ln -s postgis-${POSTGIS_VERSION%.*}.so                 /usr/lib/postgresql/${version}/lib/postgis-2.5.so;         done;     fi     && for pkg in pgextwlist; do         apt-get source postgresql-13-${pkg}         && cd $(ls -d *${pkg%?}*-*/)         && if [ -f ../$pkg.patch ]; then patch -p1 < ../$pkg.patch; fi         && if [ "$pkg" = "pgextwlist" ]; then             sed -i '/postgresql-all/d' debian/control.in             && perl -ne 'print unless /PG_TRY/ .. /PG_CATCH/' pgextwlist.c > pgextwlist.c.f             && egrep -v '(PG_END_TRY|EmitWarningsOnPlaceholders)' pgextwlist.c.f > pgextwlist.c;         fi         && pg_buildext updatecontrol         && DEB_BUILD_OPTIONS=nocheck debuild -b -uc -us         && cd ..         && for version in $DEB_PG_SUPPORTED_VERSIONS; do             for deb in postgresql-${version}-${pkg}_*.deb; do                 if [ -f $deb ]; then dpkg -i $deb; fi;             done;         done;     done     && gcc -s -shared -fPIC -o /usr/local/lib/cron_unprivileged.so cron_unprivileged.c     && apt-get purge -y ${BUILD_PACKAGES} postgresql postgresql-all postgresql-server-dev-* libpq-dev=* libmagic1 bsdmainutils     && apt-get autoremove -y     && apt-get clean     && dpkg -l | grep '^rc' | awk '{print $2}' | xargs apt-get purge -y     && if [ "$DEMO" != "true" ]; then         cd /usr/lib/postgresql/$PGVERSION/bin         && for u in clusterdb pg_archivecleanup pg_basebackup pg_isready pg_recvlogical pg_test_fsync pg_test_timing pgbench psql reindexdb vacuumdb vacuumlo *.py; do             for v in /usr/lib/postgresql/*; do                 if [ "$v" != "/usr/lib/postgresql/$PGVERSION" ] && [ -f "$v/bin/$u" ]; then                     rm $v/bin/$u                     && ln -s ../../$PGVERSION/bin/$u $v/bin/$u;                 fi;             done;         done         && set +x         && for v1 in $(ls -1d /usr/share/postgresql/* | sort -Vr); do             cd $v1/extension             && for orig in $(ls -1 *.sql | grep -v -- '--'); do                 for f in ${orig%.sql}--*.sql; do                     if [ !
-L $f ] && diff $orig $f > /dev/null; then                         echo "creating symlink $f -> $orig"                         && rm $f && ln -s $orig $f;                     fi;                 done;             done             && for e in pgq pgq_node plproxy address_standardizer address_standardizer_data_us; do                 orig=$(basename "$(find -maxdepth 1 -type f -name "$e--*--*.sql" | head -n1)")                 && if [ "x$orig" != "x" ]; then                     for f in $e--*--*.sql; do                         if [ "$f" != "$orig" ] && [ ! -L $f ] && diff $f $orig > /dev/null; then                             echo "creating symlink $f -> $orig"                             && rm $f && ln -s $orig $f;                         fi;                     done;                 fi;             done             && started=0             && for v2 in $(ls -1d /usr/share/postgresql/* | sort -Vr); do                 if [ $v1 = $v2 ]; then                     started=1;                 elif [ $started = 1 ]; then                     for d1 in extension contrib contrib/postgis-$POSTGIS_VERSION; do                         cd $v1/$d1                         && d2="$d1"                         && d1="../../${v1##*/}/$d1"                         && if [ "${d2%-*}" = "contrib/postgis" ]; then                             if  [ "${v2##*/}" = "9.6" ]; then d2="${d2%-*}-$POSTGIS_LEGACY"; fi                             && d1="../$d1";                         fi                         && d2="$v2/$d2"                         && for f in *.html *.sql *.control *.pl; do                             if [ -f $d2/$f ] && [ ! -L $d2/$f ] && diff $d2/$f $f > /dev/null; then                                 echo "creating symlink $d2/$f -> $d1/$f"                                 && rm $d2/$f && ln -s $d1/$f $d2/$f;                             fi;                         done;                     done;                 fi;             done;         done         && set -x;     fi     && rm -rf /var/lib/apt/lists/*             /var/cache/debconf/*             /builddeps             /usr/share/doc             /usr/share/man             /usr/share/info             /usr/share/locale/??             /usr/share/locale/??_??             /usr/share/postgresql/*/man             /etc/pgbouncer/*             /usr/lib/postgresql/*/bin/createdb             /usr/lib/postgresql/*/bin/createlang             /usr/lib/postgresql/*/bin/createuser             /usr/lib/postgresql/*/bin/dropdb             /usr/lib/postgresql/*/bin/droplang             /usr/lib/postgresql/*/bin/dropuser             /usr/lib/postgresql/*/bin/pg_standby             /usr/lib/postgresql/*/bin/pltcl_*     && find /var/log -type f -exec truncate --size 0 {} \;]: exit code: 29
make: *** [docker_build] Error 1
```

CI: https://github.com/HydrasDB/hydra/actions/runs/3178034025.

This is due to the failure to build older versions of PG. We only need PG 13 & 14. This PR builds 13 & 14 by setting the `PGOLDVERSIONS=13` (14 will be always built because it's the latest supported PG in Spilo)

At the same time, Spilo image is upgraded to `2.1-p7` to consume the latest bug fixes.  Diff: https://github.com/zalando/spilo/compare/2.1-p6...2.1-p7